### PR TITLE
added CRAN install instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ The drag-and-drop nature of the application means that it is easy for both R and
 
 ## Installation
 
+Install from [CRAN](https://cran.r-project.org/web/packages/designer/index.html) with:
+
 ``` r
-# Install the latest version from GitHub:
+install.packages("esquisse")
+```
+
+Or install the development version from [GitHub](https://github.com/ashbaldry/designer) with:
+
+``` r
 devtools::install_github("ashbaldry/designer")
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The drag-and-drop nature of the application means that it is easy for both R and
 Install from [CRAN](https://cran.r-project.org/web/packages/designer/index.html) with:
 
 ``` r
-install.packages("esquisse")
+install.packages("designer")
 ```
 
 Or install the development version from [GitHub](https://github.com/ashbaldry/designer) with:


### PR DESCRIPTION
https://cran.r-project.org/web/packages/designer/index.html
install.packages("designer")

Package now on CRAN. Good default to install from there. 